### PR TITLE
Default Sitemap disable with plugin activation

### DIFF
--- a/sitemap-loader.php
+++ b/sitemap-loader.php
@@ -68,6 +68,9 @@ class GoogleSitemapGeneratorLoader {
 		if (!wp_get_schedule('sm_ping_daily')) {
 			wp_schedule_event(time() + (60 * 60), 'daily', 'sm_ping_daily');
 		}
+
+		//Disable the WP core XML sitemaps.		 
+		add_filter( 'wp_sitemaps_enabled', '__return_false' );
 	}
 
 	/**


### PR DESCRIPTION
Plugin will automatically disable core sitemap plugin upon installtion/update of new version. If users deactivates our plugin the core sitemap will be enabled again.