### PR TITLE
removed no follow no index

### DIFF
--- a/sitemap.xsl
+++ b/sitemap.xsl
@@ -9,7 +9,6 @@
 			<head>
 				<title>XML Sitemap</title>
 				<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-				<meta name="robots" content="noindex,follow" />
 				<style type="text/css">
 					body {
 						font-family:"Lucida Grande","Lucida Sans Unicode",Tahoma,Verdana;


### PR DESCRIPTION
- Removed the no index from the sitemap.XSL file. After removing this it will reflect the change on the issue of no index issue raised by multiple users on WP support for sitemap.xml.