### PR TITLE
Remove default sitemap entry of WordPress sitemap from robots.txt

### DIFF
--- a/sitemap-loader.php
+++ b/sitemap-loader.php
@@ -48,6 +48,10 @@ class GoogleSitemapGeneratorLoader {
 		//Post is somehow changed (also publish to publish (=edit) is fired)
 		add_action('transition_post_status', array(__CLASS__, 'SchedulePingOnStatusChange'), 9999, 3);
 
+		add_action( 'init', function() {
+			remove_action( 'init', 'wp_sitemaps_get_server' );
+		}, 5 );
+
 		//Robots.txt request
 		add_action('do_robots', array(__CLASS__, 'CallDoRobots'), 100, 0);
 

--- a/sitemap-loader.php
+++ b/sitemap-loader.php
@@ -72,9 +72,6 @@ class GoogleSitemapGeneratorLoader {
 		if (!wp_get_schedule('sm_ping_daily')) {
 			wp_schedule_event(time() + (60 * 60), 'daily', 'sm_ping_daily');
 		}
-
-		//Disable the WP core XML sitemaps.		 
-		add_filter( 'wp_sitemaps_enabled', '__return_false' );
 	}
 
 	/**

--- a/sitemap.php
+++ b/sitemap.php
@@ -109,5 +109,6 @@ function sm_GetInitFile() {
 //Don't do anything if this file was called directly
 if (defined('ABSPATH') && defined('WPINC') && !class_exists("GoogleSitemapGeneratorLoader", false)) {
 	sm_Setup();
+	add_filter('wp_sitemaps_enabled', '__return_false');
 }
 


### PR DESCRIPTION
Ticket: [Get rid off of robots.txt sitemap entry](https://github.com/Auctollo/google-sitemap-generator-premium/issues/992)

Purpose:
- This fix handles the removal of Wordpress native sitemap entry from robots.txt

Files changed:
- google-sitemap-generator/sitemap-loader.php 

Actions performed:
- Added init action to remove `wp_sitemaps_get_server`