### PR TITLE
added support for manage priorities and frequencies for products

### DIFF
--- a/sitemap-builder.php
+++ b/sitemap-builder.php
@@ -410,7 +410,17 @@ class GoogleSitemapGeneratorStandardBuilder {
 			remove_filter("get_terms_fields", array($this, "FilterTermsQuery"), 20, 2);
 
 			foreach($terms AS $term) {
-				$gsg->AddUrl(get_term_link($term, $term->taxonomy), $term->_mod_date, $gsg->GetOption("cf_tags"), $gsg->GetOption("pr_tags"));
+				switch ($term->taxonomy) {
+					case 'category':
+						$gsg->AddUrl(get_term_link($term, $term->taxonomy), $term->_mod_date, $gsg->GetOption("cf_cats"), $gsg->GetOption("pr_cats"));
+						break;
+					case 'product_cat':
+						$gsg->AddUrl(get_term_link($term, $term->taxonomy), $term->_mod_date, $gsg->GetOption("cf_product_cat"), $gsg->GetOption("pr_product_cat"));
+						break;
+					default:
+						$gsg->AddUrl(get_term_link($term, $term->taxonomy), $term->_mod_date, $gsg->GetOption("cf_tags"), $gsg->GetOption("pr_tags"));
+						break;
+				}
 			}
 		}
 	}

--- a/sitemap-core.php
+++ b/sitemap-core.php
@@ -1169,6 +1169,7 @@ final class GoogleSitemapGenerator {
 		$this->options["sm_cf_posts"] = "monthly"; //Change frequency of posts
 		$this->options["sm_cf_pages"] = "weekly"; //Change frequency of static pages
 		$this->options["sm_cf_cats"] = "weekly"; //Change frequency of categories
+		$this->options["sm_cf_product_cat"] = "weekly"; //Change frequency of product categories
 		$this->options["sm_cf_auth"] = "weekly"; //Change frequency of author pages
 		$this->options["sm_cf_arch_curr"] = "daily"; //Change frequency of the current archive (this month)
 		$this->options["sm_cf_arch_old"] = "yearly"; //Change frequency of older archives
@@ -1179,6 +1180,7 @@ final class GoogleSitemapGenerator {
 		$this->options["sm_pr_posts_min"] = 0.2; //Minimum Priority of posts, even if autocalc is enabled
 		$this->options["sm_pr_pages"] = 0.6; //Priority of static pages
 		$this->options["sm_pr_cats"] = 0.3; //Priority of categories
+		$this->options["sm_pr_product_cat"] = 0.3; //Priority of product categories
 		$this->options["sm_pr_arch"] = 0.3; //Priority of archives
 		$this->options["sm_pr_auth"] = 0.3; //Priority of author pages
 		$this->options["sm_pr_tags"] = 0.3; //Priority of tags

--- a/sitemap-ui.php
+++ b/sitemap-ui.php
@@ -1177,6 +1177,12 @@ HTML;
 								</label>
 							</li>
 							<li>
+								<label for="sm_cf_product_cat">
+									<select id="sm_cf_product_cat" name="sm_cf_product_cat"><?php $this->HtmlGetFreqNames($this->sg->GetOption("cf_product_cat")); ?></select>
+									<?php _e('Product Categories', 'sitemap') ?>
+								</label>
+							</li>
+							<li>
 								<label for="sm_cf_arch_curr">
 									<select id="sm_cf_arch_curr" name="sm_cf_arch_curr"><?php $this->HtmlGetFreqNames($this->sg->GetOption("cf_arch_curr")); ?></select>
 									<?php _e('The current archive of this month (Should be the same like your homepage)', 'sitemap') ?>
@@ -1237,6 +1243,12 @@ HTML;
 								<label for="sm_pr_cats">
 									<select id="sm_pr_cats" name="sm_pr_cats"><?php $this->HtmlGetPriorityValues($this->sg->GetOption("pr_cats")); ?></select>
 									<?php _e('Categories', 'sitemap') ?>
+								</label>
+							</li>
+							<li>
+								<label for="sm_pr_product_cat">
+									<select id="sm_pr_product_cat" name="sm_pr_product_cat"><?php $this->HtmlGetPriorityValues($this->sg->GetOption("pr_product_cat")); ?></select>
+									<?php _e('Product Categories', 'sitemap') ?>
 								</label>
 							</li>
 							<li>


### PR DESCRIPTION
Ticket: [Settings: Manage priorities and frequencies for products](https://github.com/Auctollo/google-sitemap-generator-premium/issues/982)

Purpose:

- To add support of manage priorities and frequencies for products category

Files changed: 

- sitemap-builder.php
- sitemap-core.php
- sitemap-ui.php

Actions performed:

- add frequencies and priorities for product category
- add url for category in sitemap with  frequencies and priorities
- add default options for  frequencies and priorities
- add ui to manage frequencies and priorities
