### PR TITLE
fix 'www' prefix issue for xsl sheet url

### DIFF
--- a/sitemap-core.php
+++ b/sitemap-core.php
@@ -1365,6 +1365,22 @@ final class GoogleSitemapGenerator {
 			$url = $this->GetPluginUrl();
 			//If called over the admin area using HTTPS, the stylesheet would also be https url, even if the site frontend is not.
 			if(substr(get_bloginfo('url'), 0, 5) != "https" && substr($url, 0, 5) == "https") $url = "http" . substr($url, 5);
+
+			if (substr($_SERVER['HTTP_HOST'], 0, 4) === 'www.') {
+				if(substr(get_bloginfo('url'), 0, 5) != "https"){
+					if(strpos($url,"www.") === false){
+						$url = str_replace("http://","http://www.",$url);
+					}
+				} else{
+					if(strpos($url,"www.") == false){
+						$url = str_replace("https://","https://www.",$url);
+					}
+				}
+			}else{
+				if(strpos($url,"www.") !== false){
+					$url = str_replace("://www.","://",$url);
+				}
+			}
 			return $url . 'sitemap.xsl';
 		}
 		return '';

--- a/sitemap-core.php
+++ b/sitemap-core.php
@@ -2274,17 +2274,17 @@ final class GoogleSitemapGenerator {
 	}
 
 	public function getXslUrl($url,$host){
-		if (substr($host, 0, 4) === 'www.') {
+		if (substr($host, 0, 4) === 'www.'){
 			if(substr(get_bloginfo('url'), 0, 5) != "https"){
 				if(strpos($url,"www.") === false){
 					$url = str_replace("http://","http://www.",$url);
 				}
 			} else{
-				if(strpos($url,"www.") == false){
+				if(strpos($url,"www.") === false){
 					$url = str_replace("https://","https://www.",$url);
 				}
 			}
-		}else{
+		} else{
 			if(strpos($url,"www.") !== false){
 				$url = str_replace("://www.","://",$url);
 			}

--- a/sitemap-core.php
+++ b/sitemap-core.php
@@ -1366,21 +1366,8 @@ final class GoogleSitemapGenerator {
 			//If called over the admin area using HTTPS, the stylesheet would also be https url, even if the site frontend is not.
 			if(substr(get_bloginfo('url'), 0, 5) != "https" && substr($url, 0, 5) == "https") $url = "http" . substr($url, 5);
 
-			if (substr($_SERVER['HTTP_HOST'], 0, 4) === 'www.') {
-				if(substr(get_bloginfo('url'), 0, 5) != "https"){
-					if(strpos($url,"www.") === false){
-						$url = str_replace("http://","http://www.",$url);
-					}
-				} else{
-					if(strpos($url,"www.") == false){
-						$url = str_replace("https://","https://www.",$url);
-					}
-				}
-			}else{
-				if(strpos($url,"www.") !== false){
-					$url = str_replace("://www.","://",$url);
-				}
-			}
+			$host = $_SERVER['HTTP_HOST'];
+			$url = $this->getXslUrl($url,$host);
 			return $url . 'sitemap.xsl';
 		}
 		return '';
@@ -2284,5 +2271,24 @@ final class GoogleSitemapGenerator {
 			<div style="clear:right;"></div>
 		</div>
 		<?php
+	}
+
+	public function getXslUrl($url,$host){
+		if (substr($host, 0, 4) === 'www.') {
+			if(substr(get_bloginfo('url'), 0, 5) != "https"){
+				if(strpos($url,"www.") === false){
+					$url = str_replace("http://","http://www.",$url);
+				}
+			} else{
+				if(strpos($url,"www.") == false){
+					$url = str_replace("https://","https://www.",$url);
+				}
+			}
+		}else{
+			if(strpos($url,"www.") !== false){
+				$url = str_replace("://www.","://",$url);
+			}
+		}
+		return $url;
 	}
 }


### PR DESCRIPTION
Ticket: [Sitemap: HTTP error while generating sitemap (4.x candidate)](https://github.com/Auctollo/google-sitemap-generator-premium/issues/989)

Purpose:

- Resolve HTTP error while generating sitemap

Files changed: 
- sitemap-core.php


Actions performed:

- check if the current URL has "www" prefix
- check if WP site URL has "www" prefix
- if the site URL has a prefix and the current request URL does not 
   - remove the prefix from the XSL URL
- else if the current request URL has a prefix and the site URL does not 
  - add the prefix in the XSL URL

