### PR TITLE
Added support of links per page and product tags and product category

### DIFF
--- a/sitemap-builder.php
+++ b/sitemap-builder.php
@@ -45,6 +45,12 @@ class GoogleSitemapGeneratorStandardBuilder {
 			case "tax":
 				$this->BuildTaxonomies($gsg, $params);
 				break;
+			case "producttags":
+				$this->BuildProductTags($gsg, $params);
+				break;
+			case "productcat":
+				$this->BuildProductCategories($gsg, $params);
+				break;
 			case "externals":
 				$this->BuildExternals($gsg);
 				break;
@@ -395,6 +401,14 @@ class GoogleSitemapGeneratorStandardBuilder {
 	 */
 	public function BuildTaxonomies($gsg, $taxonomy) {
 
+		$offset = $taxonomy;
+		$linksPerPage = $gsg->GetOption("links_page");
+		if(strpos($taxonomy,"-") !== false){
+			$offset = substr($taxonomy, strrpos($taxonomy, '-') + 1);
+			$taxonomy = str_replace("-".$offset,"",$taxonomy);
+		}
+		$offset = ($offset-1) * $linksPerPage;
+
 		$enabledTaxonomies = $this->GetEnabledTaxonomies($gsg);
 		if(in_array($taxonomy, $enabledTaxonomies)) {
 
@@ -406,11 +420,24 @@ class GoogleSitemapGeneratorStandardBuilder {
 			}
 
 			add_filter("get_terms_fields", array($this, "FilterTermsQuery"), 20, 2);
-			$terms = get_terms($taxonomy, array("hide_empty" => true, "hierarchical" => false, "exclude" => $excludes));
+			$terms = get_terms($taxonomy, array('number' => $linksPerPage,'offset'=>$offset,"hide_empty" => true, "hierarchical" => false, "exclude" => $excludes));
 			remove_filter("get_terms_fields", array($this, "FilterTermsQuery"), 20, 2);
 
-			foreach($terms AS $term) {
-				$gsg->AddUrl(get_term_link($term, $term->taxonomy), $term->_mod_date, $gsg->GetOption("cf_tags"), $gsg->GetOption("pr_tags"));
+			$step = 1;
+			for ($taxCount=0; $taxCount < sizeof($terms); $taxCount++) {
+				$term = $terms[$taxCount];
+				switch ($term->taxonomy) {
+					case 'category':
+						$gsg->AddUrl(get_term_link($term, $step), $term->_mod_date, $gsg->GetOption("cf_cats"), $gsg->GetOption("pr_cats"));
+						break;
+					case 'product_cat':
+						$gsg->AddUrl(get_term_link($term, $step), $term->_mod_date, $gsg->GetOption("cf_product_cat"), $gsg->GetOption("pr_product_cat"));
+						break;
+					default:
+						$gsg->AddUrl(get_term_link($term, $step), $term->_mod_date, $gsg->GetOption("cf_tags"), $gsg->GetOption("pr_tags"));
+						break;
+				}
+				$step++;
 			}
 		}
 	}
@@ -433,6 +460,60 @@ class GoogleSitemapGeneratorStandardBuilder {
 			if($taxonomy && wp_count_terms($taxonomy->name, array('hide_empty' => true)) > 0) $taxList[] = $taxonomy->name;
 		}
 		return $taxList;
+	}
+
+	/**
+	 * Returns the enabled Product tags. Only Product Tags with posts are returned.
+	 *
+	 * @param GoogleSitemapGenerator $gsg
+	 * @return array
+	 */
+	public function BuildProductTags(GoogleSitemapGenerator $gsg, $offset) {
+		$linksPerPage = $gsg->GetOption("links_page");
+		$offset = ($offset-1) * $linksPerPage;
+
+		add_filter("get_terms_fields", array($this, "FilterTermsQuery"), 20, 2);
+		$terms = get_terms( 'product_tag', array('number' => $linksPerPage,'offset'=>$offset));
+		remove_filter("get_terms_fields", array($this, "FilterTermsQuery"), 20, 2);
+		$term_array = array();
+
+		if ( ! empty( $terms ) && ! is_wp_error( $terms ) ){
+		    foreach ( $terms as $term ) {
+		        $term_array[] = $term->name;
+		        $url = get_term_link($term);
+				$gsg->AddUrl($url, $term->_mod_date, $gsg->GetOption("cf_auth"), $gsg->GetOption("pr_auth"), $term->ID, array(), array(), '');
+		    }
+		}
+	}
+
+	/**
+	 * Returns the enabled Product Categories. Only Product Categories with posts are returned.
+	 *
+	 * @param GoogleSitemapGenerator $gsg
+	 * @return array
+	 */
+
+	public function BuildProductCategories(GoogleSitemapGenerator $gsg, $offset) {
+		$linksPerPage = $gsg->GetOption("links_page");
+		$offset = ($offset-1) * $linksPerPage;
+		$excludes = array();
+		$exclCats = $gsg->GetOption("b_exclude_cats"); // Excluded cats
+		if($exclCats) $excludes = $exclCats;
+		add_filter("get_terms_fields", array($this, "FilterTermsQuery"), 20, 2);
+		$category = get_terms( 'product_cat', array('number' => $linksPerPage,'offset'=>$offset,"exclude" => $excludes));
+		remove_filter("get_terms_fields", array($this, "FilterTermsQuery"), 20, 2);
+		$cat_array = array();
+		if ( ! empty( $category ) && ! is_wp_error( $category ) ){
+			$step = 1;
+		    foreach ( $category as $cat ) {
+		        $cat_array[] = $cat->name;
+				if($cat && wp_count_terms($cat->name, array('hide_empty' => true)) > 0){
+					$step++;
+					$url = get_term_link($cat);
+					$gsg->AddUrl($url, $cat->_mod_date, $gsg->GetOption("cf_product_cat"), $gsg->GetOption("pr_product_cat"),$cat->ID, array(), array(), '');
+				}
+		    }
+		}
 	}
 
 	/**
@@ -463,12 +544,56 @@ class GoogleSitemapGeneratorStandardBuilder {
 
 		$blogUpdate = strtotime(get_lastpostmodified('gmt'));
 
+		$linksPerPage = $gsg->GetOption("links_page");
+
 		$gsg->AddSitemap("misc", null, $blogUpdate);
 
 
 		$taxonomies = $this->GetEnabledTaxonomies($gsg);
+		$taxonomiesToExclude = array("product_tag", "product_cat");
 		foreach($taxonomies AS $tax) {
-			$gsg->AddSitemap("tax", $tax, $blogUpdate);
+			if(!in_array($tax,$taxonomiesToExclude)){
+				$step = 1;
+				$taxs = get_terms( $tax );
+				for ($taxCount=0; $taxCount < sizeof($taxs); $taxCount++) {
+					if($taxCount % $linksPerPage == 0 && $taxs[$taxCount]->taxonomy != ""){
+						$gsg->AddSitemap("tax-".$taxs[$taxCount]->taxonomy,$step, $blogUpdate);
+						$step = $step +1;
+					}
+				}
+			}
+		}
+
+		//if Product Tags is enabled from sitemap settings
+		if($gsg->GetOption('product_tags') == true){
+			$productTags = get_terms( 'product_tag' );
+			if ( ! empty( $productTags ) && ! is_wp_error( $productTags ) ){
+				$step = 1;
+				for ($productCount=0; $productCount < sizeof($productTags); $productCount++) { 
+					if($productCount % $linksPerPage == 0){
+						$gsg->AddSitemap("producttags", $step, $blogUpdate);
+						$step = $step +1;
+					}
+				}
+			}
+		}
+
+		//if Product category is enabled from sitemap settings
+		if($gsg->GetOption('in_product_cat') == true){
+			$excludes = array();
+			$exclCats = $gsg->GetOption("b_exclude_cats"); // Excluded cats
+			if($exclCats) $excludes = $exclCats;
+			$productCat = get_terms( 'product_cat' , array("exclude" => $excludes) );
+
+			if ( ! empty( $productCat ) && ! is_wp_error( $productCat ) ){
+				$step = 1;
+				for ($productCount=0; $productCount < sizeof($productCat); $productCount++) { 
+					if($productCount % $linksPerPage == 0){
+						$gsg->AddSitemap("productcat", $step, $blogUpdate);
+						$step = $step +1;
+					}
+				}
+			}
 		}
 
 		$pages = $gsg->GetPages();

--- a/sitemap-core.php
+++ b/sitemap-core.php
@@ -948,7 +948,7 @@ final class GoogleSitemapGenerator {
 	 */
 	public function GetCustomTaxonomies() {
 		$taxonomies = get_taxonomies(array("public" => 1));
-		return array_diff($taxonomies, array("category", "post_tag", "nav_menu", "link_category", "post_format"));
+		return array_diff($taxonomies, array("category", "post_tag", "nav_menu", "link_category", "product_tag", "product_cat", "post_format"));
 	}
 
 	/**
@@ -1158,6 +1158,8 @@ final class GoogleSitemapGenerator {
 		$this->options["sm_in_posts_sub"] = false; //Include post pages (<!--nextpage--> tag)
 		$this->options["sm_in_pages"] = true; //Include static pages
 		$this->options["sm_in_cats"] = false; //Include categories
+		$this->options["sm_product_tags"] = true; //Hide product tags in sitemap
+		$this->options["sm_in_product_cat"] = false; //Include product categories
 		$this->options["sm_in_arch"] = false; //Include archives
 		$this->options["sm_in_auth"] = false; //Include author pages
 		$this->options["sm_in_tags"] = false; //Include tag pages
@@ -1194,6 +1196,7 @@ final class GoogleSitemapGenerator {
 		$this->options["sm_i_lastping"] = 0; //When was the last ping
 		$this->options["sm_i_supportfeed"] = true; //shows the support feed
 		$this->options["sm_i_supportfeed_cache"] = 0; //Last refresh of support feed
+		$this->options["sm_links_page"] = 10; // Link per page support with default value 10.
 	}
 
 	/**

--- a/sitemap-ui.php
+++ b/sitemap-ui.php
@@ -367,6 +367,10 @@ class GoogleSitemapGeneratorUI {
 				//Options of the category "Priorities" are float
 				} else if(substr($k,0,6)=="sm_pr_") {
 					$this->sg->SetOption($k,(float) $_POST[$k]);
+				} else if($k == "sm_links_page"){
+					$this->sg->SetOption($k,(float) $_POST[$k]);
+				} else if(substr($k,0,3) == "sm_"){
+					$this->sg->SetOption($k,(bool) $_POST[$k]);
 				}
 			}
 
@@ -1018,6 +1022,18 @@ HTML;
 								</label>
 							</li>
 							<li>
+								<label for="sm_in_product_cat">
+									<input type="checkbox" id="sm_in_product_cat" name="sm_in_product_cat"  <?php echo ($this->sg->GetOption("in_product_cat")==true?"checked=\"checked\"":"") ?> />
+									<?php _e('Include product categories', 'sitemap') ?>
+								</label>
+							</li>
+							<li>
+								<label for="sm_product_tags">
+									<input type="checkbox" id="sm_product_tags" name="sm_product_tags"  <?php echo ($this->sg->GetOption("product_tags")==true?"checked=\"checked\"":"") ?> />
+									<?php _e('Include product tags', 'sitemap') ?>
+								</label>
+							</li>
+							<li>
 								<label for="sm_in_pages">
 									<input type="checkbox" id="sm_in_pages" name="sm_in_pages"  <?php echo ($this->sg->GetOption("in_pages")==true?"checked=\"checked\"":"") ?> />
 									<?php _e('Include static pages', 'sitemap') ?>
@@ -1119,6 +1135,14 @@ HTML;
 									<?php _e('Include the last modification time.', 'sitemap') ?>
 								</label><br />
 								<small><?php _e('This is highly recommended and helps the search engines to know when your content has changed. This option affects <i>all</i> sitemap entries.', 'sitemap') ?></small>
+							</li>
+						</ul>
+						<ul>
+							<li>
+								<label for="sm_links_page">
+									<b><?php _e('Links per page', 'sitemap') ?>:</b>
+									<input type="number" name="sm_links_page" id="sm_links_page" style="width:50px; margin-left:10px;" value="<?php echo esc_attr($this->sg->GetOption("links_page")); ?>" />
+								</label>
 							</li>
 						</ul>
 


### PR DESCRIPTION
Ticket: [Investigate: the links per page should be working for tags and categories (posts/pages and products)](https://github.com/Auctollo/google-sitemap-generator-premium/issues/996)

Purpose:

- Add links per page for tags and categories

Files changed: 
- sitemap-builder.php
- sitemap-core.php
- sitemap-ui.php


Actions performed:

- Generate content for `producttags` and `productcat`
- Add UI options to include `Product tag` and `Product categories` 
- Also add options for `Links per page`
- Create index URL and inner pages according new link per page mechanism
