### PR TITLE
added custom settings for single pages

### DIFF
--- a/class-googlesitemapgeneratorstandardbuilder.php
+++ b/class-googlesitemapgeneratorstandardbuilder.php
@@ -231,6 +231,9 @@ class GoogleSitemapGeneratorStandardBuilder {
 					}
 				}
 
+				if (file_exists(trailingslashit( dirname( __FILE__ ) ) . 'custom-settings.php'))
+					require_once trailingslashit( dirname( __FILE__ ) ) . 'custom-settings.php';
+
 				foreach ( $posts as $post ) {
 
 					// Fill the cache with our DB result. Since it's incomplete (no text-content for example), we will clean it later.
@@ -261,11 +264,17 @@ class GoogleSitemapGeneratorStandardBuilder {
 							$priority = $minimum_priority;
 						}
 
+						$last_mod = $gsg->get_timestamp_from_my_sql( $post->post_modified_gmt && '0000-00-00 00:00:00' !== $post->post_modified_gmt ? $post->post_modified_gmt : $post->post_date_gmt );
+						$change_freq = ( 'page' === $post_type ? $change_frequency_for_pages : $change_frequency_for_posts );
+
+						if (function_exists('GoogleSitemapGenerator_CustomPostSettings'))
+							GoogleSitemapGenerator_CustomPostSettings($post->ID, $permalink, $last_mod, $change_freq, $priority);
+
 						// Add the URL to the sitemap.
 						$gsg->add_url(
 							$permalink,
-							$gsg->get_timestamp_from_my_sql( $post->post_modified_gmt && '0000-00-00 00:00:00' !== $post->post_modified_gmt ? $post->post_modified_gmt : $post->post_date_gmt ),
-							( 'page' === $post_type ? $change_frequency_for_pages : $change_frequency_for_posts ),
+							$last_mod,
+							$change_freq,
 							$priority,
 							$post->ID
 						);

--- a/custom-settings-sample.php
+++ b/custom-settings-sample.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * change settings for single pages or posts
+ *
+ * @package Sitemap
+ * @author  maruhe
+ */
+
+/*
+rename this file to custom-settings.php to activate custom settings
+*/
+
+function GoogleSitemapGenerator_CustomPostSettings($postID, &$permalink, &$last_mod, &$change_freq, &$priority) {
+    global $wpdb;
+    
+    if ($postID == 35) {
+        #sample 1 for page 35 => set priority to 100
+        $priority = 1;
+    } else if ($postID == 88) {
+        #sample 2 for post 88 => get update-time from custom table
+        $priority = 1;
+        $change_freq = 'daily';
+        try {
+            $last_mod = $wpdb->get_var("SELECT UNIX_TIMESTAMP(`DateTime`) FROM " . $wpdb->base_prefix . "my_table ORDER BY `DateTime` DESC LIMIT 1;");
+        } catch (Throwable $e) {
+            $last_mod = time();
+        }
+    }
+}


### PR DESCRIPTION
using custom-settings.php it's now possible to change settings for single pages or posts in php code. using the filename 'custom-settings-sample.php' here will not overwrite the customised file on plugin-updates.