### PR TITLE
fix dissable aioseo sitemap when add new site in multisite mode

### DIFF
--- a/sitemap.php
+++ b/sitemap.php
@@ -73,6 +73,20 @@ add_action( 'plugins_loaded', function() {
 
 add_action( 'transition_post_status', 'indexnow_after_post_save', 10, 3 ); //send to indexNow
 
+add_action('wpmu_new_blog', 'disable_conflict_sitemaps_on_new_blog', 10, 6);
+
+function disable_conflict_sitemaps_on_new_blog($blog_id, $user_id, $domain, $path, $site_id, $meta) {
+    switch_to_blog($blog_id);
+    $aioseo_option_key = 'aioseo_options';
+    if (get_option($aioseo_option_key) !== null) {
+        $aioseo_options = get_option($aioseo_option_key);
+        $aioseo_options = json_decode($aioseo_options, true);
+        $aioseo_options['sitemap']['general']['enable'] = false;
+        update_option($aioseo_option_key, json_encode($aioseo_options));
+    }
+    restore_current_blog();
+}
+
 /**
  * Google analytics .
  */


### PR DESCRIPTION
When user added new site in multisite mode the aioseo sitemap automatically applied for new site if it was installed on site and deactivated on the others sites. Now aioseo is deactivated for new sites.