### PR TITLE
fix: Fixing issue, when custom taxonomies is not shown on index sitemap

### DIFF
--- a/class-googlesitemapgeneratorstandardbuilder.php
+++ b/class-googlesitemapgeneratorstandardbuilder.php
@@ -848,7 +848,7 @@ class GoogleSitemapGeneratorStandardBuilder {
 		
 		foreach ( $enabled_taxonomies as $taxonomy ) {
 			if ( ! in_array( $taxonomy, $taxonomies_to_exclude, true ) ) {
-				$terms = get_terms( $taxonomy, array( 'exclude' => $excludes ) );
+				$terms = $this->get_terms( $taxonomy, array( 'exclude' => $excludes ) );
 				$terms_by_taxonomy[ $taxonomy ] = $terms;
 			}
 		}
@@ -1028,6 +1028,32 @@ class GoogleSitemapGeneratorStandardBuilder {
 		}
 
 		return $urls;
+	}
+
+	public function get_terms( $taxonomy, $args = [] ) {
+		global $wpdb;
+
+		$sql = 'SELECT DISTINCT * 
+				FROM '.$wpdb->prefix.'terms t 
+				INNER JOIN '.$wpdb->prefix.'term_taxonomy tax 
+				ON `tax`.term_id = `t`.term_id
+				WHERE ( `tax`.taxonomy = \'' . $taxonomy . '\')';
+
+		if ( ! empty( $args ) ) {
+			foreach ( $args as $arg_key => $arg_values ) {
+				switch ( $arg_key ) {
+					case 'exclude':
+						foreach ( $arg_values as $term_id ) {
+							$sql .= ' AND `tax`.term_id != ' . $term_id;
+						}
+						break;
+				}
+			}
+		}
+
+		$result =  $wpdb->get_results($sql);
+		
+		return $result; 
 	}
 }
 


### PR DESCRIPTION
When outputting custom taxonomies in the sitemap, the get_terms() function was used, but it returned an "Invalid Taxonomy" error because the function was called before the taxonomy was registered.
Therefore, a new function was created that directly accesses the database and receives the necessary taxonomies.
![image](https://github.com/Auctollo/google-sitemap-generator/assets/272181/6d84877d-39cb-4ba3-ac6a-e2267bde3e38)
![image](https://github.com/Auctollo/google-sitemap-generator/assets/272181/1d9d6084-f09c-4792-a42b-f67e13805fc9)