### PR TITLE
fix: Fixing logic for getting posts on sitemap page for post types Pa)ge and Post

### DIFF
--- a/class-googlesitemapgeneratorstandardbuilder.php
+++ b/class-googlesitemapgeneratorstandardbuilder.php
@@ -158,7 +158,7 @@ class GoogleSitemapGeneratorStandardBuilder {
 				ORDER BY
 					p.post_date_gmt DESC
 				LIMIT
-					{$limit}
+					%d, %d
 			";
 			// Query for counting all relevant posts for this post type.
 			$qsc = "
@@ -173,12 +173,15 @@ class GoogleSitemapGeneratorStandardBuilder {
 					{$ex_post_s_q_l}
 					{$ex_cat_s_q_l}
 			";
+
+			// Calculate the offset based on the limit and links_per_page
+			$offset = max( 0, ( $limit - $links_per_page ) );
+
 			// phpcs:disable
-			$q = $wpdb->prepare( $qs, $post_type );
+			$q = $wpdb->prepare( $qs, $post_type, $offset, $links_per_page );
 
 			// phpcs:enable
 			$posts      = $wpdb->get_results( $q ); // phpcs:ignore
-			$posts      = array_slice( $posts, ( $limit - $links_per_page ) );
 			$post_count = count( $posts );
 			if ( ( $post_count ) > 0 ) {
 				/**


### PR DESCRIPTION
Before that, all the posts were extracted, and a slised needed items of them was made to display them on the page. 
The fix is to extract from the database at once the required count by offset and not all at once.