### PR TITLE
fix: Fixing order for post and page post_types

### DIFF
--- a/class-googlesitemapgeneratorstandardbuilder.php
+++ b/class-googlesitemapgeneratorstandardbuilder.php
@@ -156,7 +156,7 @@ class GoogleSitemapGeneratorStandardBuilder {
 					{$ex_post_s_q_l}
 					{$ex_cat_s_q_l}
 				ORDER BY
-					p.post_date_gmt DESC
+					p.post_date_gmt ASC
 				LIMIT
 					{$limit}
 			";


### PR DESCRIPTION
Fix sorting of 'Post' and 'Page' post types on pages with more than 1000 entries.
Example:
On the /post-sitemap.xml page, records that were created earlier will be displayed.
And on others, for example /post-sitemap2.xml, records that were created later will be displayed.