### PR TITLE
fix: Fixing excluded items, that was automatically included from robots.txt file

### DIFF
--- a/sitemap-core.php
+++ b/sitemap-core.php
@@ -1215,6 +1215,8 @@ final class GoogleSitemapGenerator {
 			}
 		}
 
+		$rules = apply_filters( 'sm_robots_disallowed_ids', array_unique( $rules ) );
+		
 		return $rules;
 	}
 	/**


### PR DESCRIPTION
When the sitemap is displayed, the code includes a robots.txt check for a disallowed link.
These disallowed links are added to exclude posts.
Added a new filter that allows you to remove required links.

/**
 * Return the pages to the sitemap that were deleted using the robots.txt file
 */
```
add_filter( 'sm_robots_disallowed_ids', 'sm_robots_disallowed_ids', 10 );
function sm_robots_disallowed_ids( $rules ) {
    
    $remove_from_excludes_ids = [ '0' ];

    foreach ( $remove_from_excludes_ids as $id ) {
        if ( ( $key = array_search( $id, $rules ) ) !== false ) {
            unset( $rules[ $key ] );
        }
    }

    return $rules;
}
```