### PR TITLE
feat: Fixing Google search console notice 'XML tag not specified. A r…

### DIFF
--- a/sitemap-core.php
+++ b/sitemap-core.php
@@ -2141,7 +2141,7 @@ final class GoogleSitemapGenerator {
 		if ( $html ) {
 			ob_start();
 		} else {
-			header( 'Content-Type: text/xml; charset=utf-8' );
+			header( 'Content-Type: application/xml; charset=utf-8' );
 		}
 
 		if ( empty( $options['params'] ) || 'index' === $options['params'] ) {


### PR DESCRIPTION
…equired tag has not been specified. Please add it and resubmit.'