### PR TITLE
Fix: Ensure set_time_limit() receives a valid integer value

### DIFF
--- a/sitemap-core.php
+++ b/sitemap-core.php
@@ -2081,7 +2081,7 @@ final class GoogleSitemapGenerator {
 		}
 		if ( $this->get_option( 'b_time' ) !== -1 && $this->get_option( 'b_time' ) !== null ) {
 			if ( strpos( $disable_functions, 'set_time_limit' ) === false ) {
-				set_time_limit( $this->get_option( 'b_time' ) );
+				set_time_limit( (int)$this->get_option( 'b_time' ) );
 			}
 		}
 


### PR DESCRIPTION
- Cast the value returned by `$this->get_option('b_time')` to an integer before passing it to `set_time_limit()`.
- This change resolves the deprecation warning in newer PHP versions that disallow passing null to `set_time_limit()`.
- Ensures compatibility with both old and new PHP versions by always providing a valid integer to the `set_time_limit()` function.